### PR TITLE
Tweak Runtime API error handling

### DIFF
--- a/bootstrap
+++ b/bootstrap
@@ -1,8 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-APP_PARTS=(${_HANDLER//\// })
-tmpfile=`mktemp`
-echo "(require '${APP_PARTS[0]})" | cat - /opt/runtime.cljs > $tmpfile
+bin_dir=${BIN_DIR:-/opt}
+app_parts=(${_HANDLER//\// })
 
-/opt/lumo $tmpfile
+"$bin_dir/lumo" --classpath ".:${bin_dir}" -e "(require (quote ${app_parts[0]}))" -m runtime

--- a/runtime.cljs
+++ b/runtime.cljs
@@ -53,12 +53,12 @@
                  ;; We treat all errors from the API as an unrecoverable error. This is
                  ;; because the API returns 4xx errors for responses that are too long. In
                  ;; that case, we simply log the output and fail.
-                 (assert (= status 200) (str "Error from Runtime API\n"
-                                             (-> {:url url
-                                                  :response res
-                                                  :error runtime-error}
-                                                 (clj->js)
-                                                 (js/JSON.stringify nil 2))))
+                 (assert (successful? status) (str "Error from Runtime API\n"
+                                                   (-> {:url url
+                                                        :response res
+                                                        :error runtime-error}
+                                                       (clj->js)
+                                                       (js/JSON.stringify nil 2))))
                  res)))))
 
 (defonce state (atom nil))
@@ -74,12 +74,12 @@
                  ;; We treat all errors from the API as an unrecoverable error. This is
                  ;; because the API returns 4xx errors for responses that are too long. In
                  ;; that case, we simply log the output and fail.
-                 (assert (= status 200) (str "Error from Runtime API\n"
-                                             (-> {:url url
-                                                  :response response
-                                                  :context @state}
-                                                 (clj->js)
-                                                 (js/JSON.stringify nil 2))))
+                 (assert (successful? status) (str "Error from Runtime API\n"
+                                                   (-> {:url url
+                                                        :response response
+                                                        :context @state}
+                                                       (clj->js)
+                                                       (js/JSON.stringify nil 2))))
 
                  (let [context {:aws-request-id aws-request-id
                                 :lambda-runtime-invoked-function-arn lambda-runtime-invoked-function-arn}]
@@ -100,11 +100,11 @@
                                          js/JSON.stringify)}))))
         (.then (fn [{:keys [status]
                      :as response}]
-                 (assert (= status 202) (str "Error from Runtime API\n"
-                                             (-> {:context @state
-                                                  :response response}
-                                                 (clj->js)
-                                                 (js/JSON.stringify nil 2))))))
+                 (assert (successful? status) (str "Error from Runtime API\n"
+                                                   (-> {:context @state
+                                                        :response response}
+                                                       (clj->js)
+                                                       (js/JSON.stringify nil 2))))))
         (.catch (fn [err]
                   (post-error {:error err
                                :context (:context @state)})))

--- a/runtime.cljs
+++ b/runtime.cljs
@@ -3,6 +3,10 @@
 
 (def runtime-path (str "http://" (.-AWS_LAMBDA_RUNTIME_API js/process.env) "/2018-06-01/runtime"))
 
+(defn successful?
+  [status]
+  (<= 200 status 299))
+
 (defn request [{:keys [url method headers body]
                 :or   {method :get}}]
   (js/Promise.
@@ -33,50 +37,76 @@
 
 (defn post-error [{error :error
                    {aws-request-id :aws-request-id} :context}]
-  (let [url (str runtime-path "/invocation/" aws-request-id "/error")]
+  (let [url (str runtime-path "/invocation/" aws-request-id "/error")
+        runtime-error #js {:errorType (.-name error)
+                           :errorMessage (.-message error)
+                           :stackTrace (-> (or (.-stack error) "")
+                                           (.split "\n")
+                                           (.slice 1))}]
     (-> (request {:url url
                   :headers {"Content-Type" "application/json"
                             "Lambda-Runtime-Function-Error-Type" (.-name error)}
-                  :body (js/JSON.stringify #js {:errorType (.-name error)
-                                                :errorMessage (.-message error)
-                                                :stackTrace (-> (or (.-stack error) "")
-                                                                (.split "\n")
-                                                                (.slice 1))})})
+                  :body (js/JSON.stringify runtime-error)})
         (.then (fn [{:keys [status]
                      :as res}]
-                 (assert (= status 200)
-                         (str "Unexpected " url "response: " (js/JSON.stringify res)))
+                 ;; We treat all errors from the API as an unrecoverable error. This is
+                 ;; because the API returns 4xx errors for responses that are too long. In
+                 ;; that case, we simply log the output and fail.
+                 (assert (= status 200) (str "Error from Runtime API\n"
+                                             (-> {:url url
+                                                  :response res
+                                                  :error runtime-error}
+                                                 (clj->js)
+                                                 (js/JSON.stringify nil 2))))
                  res)))))
 
 (defonce state (atom nil))
 
 (defn start []
-  (-> (request {:url (str runtime-path "/invocation/next")})
-      (.then (fn [{:keys                                                                       [status body]
-                   {aws-request-id                      "lambda-runtime-aws-request-id"
-                    lambda-runtime-invoked-function-arn "lambda-runtime-invoked-function-arn"} :headers
-                   :as                                                                         response}]
-               (let [context {:aws-request-id aws-request-id
-                              :lambda-runtime-invoked-function-arn lambda-runtime-invoked-function-arn}]
-                 (swap! state assoc :context context)
-                 (assert (= status 200) (str "Unexpected /invocation/next response: " (pr-str response)))
-                 {:event   (-> (js/JSON.parse body)
-                               js->clj)
-                  :context context})))
-      (.then handle)
-      (.then (fn [response]
-               (let [{:keys [aws-request-id]} (:context @state)]
-                 (request {:url    (str runtime-path "/invocation/" aws-request-id "/response")
-                           :method :post
-                           :headers {"Content-Type" "application/json"}
-                           :body   (-> (clj->js response)
-                                       js/JSON.stringify)}))))
-      (.then (fn [{:keys [status]
-                   :as response}]
-               (assert (= status 202) (str "Unexpected /invocation/response response:" (pr-str response)))))
-      (.catch (fn [err]
-                (post-error {:error err
-                             :context (:context @state)})))
-      (.then start)))
+  (let [url (str runtime-path "/invocation/next")]
+    (-> (request {:url url})
+        (.then (fn [{:keys [status body]
+                     {aws-request-id "lambda-runtime-aws-request-id"
+                      lambda-runtime-invoked-function-arn "lambda-runtime-invoked-function-arn"} :headers
+                     :as response}]
+
+                 ;; We treat all errors from the API as an unrecoverable error. This is
+                 ;; because the API returns 4xx errors for responses that are too long. In
+                 ;; that case, we simply log the output and fail.
+                 (assert (= status 200) (str "Error from Runtime API\n"
+                                             (-> {:url url
+                                                  :response response
+                                                  :context @state}
+                                                 (clj->js)
+                                                 (js/JSON.stringify nil 2))))
+
+                 (let [context {:aws-request-id aws-request-id
+                                :lambda-runtime-invoked-function-arn lambda-runtime-invoked-function-arn}]
+                   (swap! state assoc :context context)
+
+                   {:event   (-> (js/JSON.parse body)
+                                 js->clj)
+                    :context context})))
+
+        (.then handle)
+
+        (.then (fn [response]
+                 (let [{:keys [aws-request-id]} (:context @state)]
+                   (request {:url    (str runtime-path "/invocation/" aws-request-id "/response")
+                             :method :post
+                             :headers {"Content-Type" "application/json"}
+                             :body   (-> (clj->js response)
+                                         js/JSON.stringify)}))))
+        (.then (fn [{:keys [status]
+                     :as response}]
+                 (assert (= status 202) (str "Error from Runtime API\n"
+                                             (-> {:context @state
+                                                  :response response}
+                                                 (clj->js)
+                                                 (js/JSON.stringify nil 2))))))
+        (.catch (fn [err]
+                  (post-error {:error err
+                               :context (:context @state)})))
+        (.then start))))
 
 (start)

--- a/runtime.cljs
+++ b/runtime.cljs
@@ -44,6 +44,7 @@
                                            (.split "\n")
                                            (.slice 1))}]
     (-> (request {:url url
+                  :method :post
                   :headers {"Content-Type" "application/json"
                             "Lambda-Runtime-Function-Error-Type" (.-name error)}
                   :body (js/JSON.stringify runtime-error)})


### PR DESCRIPTION
This patch adds a bit more information to the assert message in case the
Runtime API does not return 200, in particular for /error calls. This way it's
easier to debug what really happened, before the actual runtime error was never
showing up in the CloudWatch logs.