### PR TITLE
Force removal so that make clean does not die

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ all: ${RUNTIME_PACKAGE}
 .PHONY: publish clean
 
 clean:
-	rm ${RUNTIME_PACKAGE}
+	rm -f ${RUNTIME_PACKAGE}
 
 ${RUNTIME_PACKAGE}:
 ifndef LUMO_BIN_PATH


### PR DESCRIPTION
It was previously failing hard and that's not what we want when you do things
like make clean publish.